### PR TITLE
Add Inbuilt tools API abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ballerina Deepseek Model Provider Library
 
 [![Build](https://github.com/ballerina-platform/module-ballerinax-ai.deepseek/workflows/CI/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-ai.deepseek/actions?query=workflow%3ACI)
-[![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-ai.deepseek.svg)](https://github.com/ballerina-platform/module-ballerinax-ai.deepseek/commits/master)
+[![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-ai.deepseek.svg)](https://github.com/ballerina-platform/module-ballerinax-ai.deepseek/commits/main)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## Overview

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ icon="icon.png"
 name = "ai.deepseek"
 org = "ballerinax"
 repository = "https://github.com/ballerina-platform/module-ballerinax-ai.deepseek"
-version = "1.1.1"
+version = "1.1.2"
 
 [platform.java21]
 graalvmCompatible = true
@@ -15,5 +15,17 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ai.deepseek-native"
-version = "1.1.1"
-path = "../native/build/libs/ai.deepseek-native-1.1.1.jar"
+version = "1.1.2"
+path = "../native/build/libs/ai.deepseek-native-1.1.2-SNAPSHOT.jar"
+
+[[dependency]]
+org="ballerina"
+name="ai"
+version="1.10.0"
+repository="local"
+
+[[dependency]]
+org="ballerina"
+name="data.jsondata"
+version="1.1.4"
+repository="local"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ icon="icon.png"
 name = "ai.deepseek"
 org = "ballerinax"
 repository = "https://github.com/ballerina-platform/module-ballerinax-ai.deepseek"
-version = "1.1.2"
+version = "1.2.0"
 
 [platform.java21]
 graalvmCompatible = true
@@ -15,13 +15,13 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ai.deepseek-native"
-version = "1.1.2"
-path = "../native/build/libs/ai.deepseek-native-1.1.2-SNAPSHOT.jar"
+version = "1.2.0"
+path = "../native/build/libs/ai.deepseek-native-1.2.0-SNAPSHOT.jar"
 
 [[dependency]]
 org="ballerina"
 name="ai"
-version="1.10.0"
+version="1.11.0"
 repository="local"
 
 [[dependency]]

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "ai-deepseek-compiler-plugin"
 class = "io.ballerina.lib.ai.deepseek.AiDeepseekCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ai.deepseek-compiler-plugin-1.1.1.jar"
+path = "../compiler-plugin/build/libs/ai.deepseek-compiler-plugin-1.1.2-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.0.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "ai-deepseek-compiler-plugin"
 class = "io.ballerina.lib.ai.deepseek.AiDeepseekCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ai.deepseek-compiler-plugin-1.1.2-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/ai.deepseek-compiler-plugin-1.2.0-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.0.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.xmldata"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.0"
+distribution-version = "2201.13.0"
 
 [[package]]
 org = "ballerina"
 name = "ai"
-version = "1.7.0"
+version = "1.10.0"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "data.jsondata"},
@@ -72,7 +72,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.3"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.xmldata"
-version = "1.5.2"
+version = "1.6.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -110,7 +110,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.8"
+version = "2.15.4"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -258,7 +258,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.14.0"
+version = "2.17.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -274,7 +274,7 @@ version = "1.2.0"
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -295,7 +295,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.14.1"
+version = "2.15.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -308,7 +308,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -325,7 +325,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"},
@@ -349,7 +349,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -391,7 +391,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "ai.deepseek"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
 	{org = "ballerina", name = "ai"},
 	{org = "ballerina", name = "http"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.0"
+distribution-version = "2201.12.0"
 
 [[package]]
 org = "ballerina"
 name = "ai"
-version = "1.10.0"
+version = "1.11.0"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "data.jsondata"},
@@ -110,7 +110,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.15.4"
+version = "2.14.9"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -134,10 +134,6 @@ dependencies = [
 	{org = "ballerina", name = "observe"},
 	{org = "ballerina", name = "time"},
 	{org = "ballerina", name = "url"}
-]
-modules = [
-	{org = "ballerina", packageName = "http", moduleName = "http"},
-	{org = "ballerina", packageName = "http", moduleName = "http.httpscerr"}
 ]
 
 [[package]]
@@ -258,7 +254,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.17.0"
+version = "2.14.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -295,7 +291,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.15.0"
+version = "2.14.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -308,7 +304,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.0"
+version = "1.6.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -391,10 +387,9 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "ai.deepseek"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
 	{org = "ballerina", name = "ai"},
-	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "time"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -135,6 +135,10 @@ dependencies = [
 	{org = "ballerina", name = "time"},
 	{org = "ballerina", name = "url"}
 ]
+modules = [
+	{org = "ballerina", packageName = "http", moduleName = "http"},
+	{org = "ballerina", packageName = "http", moduleName = "http.httpscerr"}
+]
 
 [[package]]
 org = "ballerina"
@@ -390,6 +394,7 @@ name = "ai.deepseek"
 version = "1.2.0"
 dependencies = [
 	{org = "ballerina", name = "ai"},
+	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "time"}

--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -85,8 +85,22 @@ public isolated client class ModelProvider {
     # + tools - Tool definitions to be used for the tool call
     # + stop - Stop sequence to stop the completion
     # + return - Function to be called, chat response or an error in-case of failures
-    isolated remote function chat(ai:ChatMessage[]|ai:ChatUserMessage messages, ai:ChatCompletionFunctions[] tools, string? stop = ())
+    isolated remote function chat(ai:ChatMessage[]|ai:ChatUserMessage messages,
+            (ai:ChatCompletionFunctions|ai:InbuiltModelTool)[] tools = [], string? stop = ())
     returns ai:ChatAssistantMessage|ai:Error {
+        string[] unsupportedTools = [];
+        ai:ChatCompletionFunctions[] functionTools = [];
+        foreach var tool in tools {
+            if tool is ai:InbuiltModelTool {
+                unsupportedTools.push(tool.name);
+            } else {
+                functionTools.push(tool);
+            }
+        }
+        if unsupportedTools.length() > 0 {
+            return error ai:Error(string `Inbuilt tools [${string:'join(", ", ...unsupportedTools)}] are not supported.`);
+        }
+
         observe:ChatSpan span = observe:createChatSpan(self.modelType);
         span.addProvider("deepseek");
         if stop is string {
@@ -111,10 +125,10 @@ public isolated client class ModelProvider {
             stop: stop
         };
 
-        if tools.length() > 0 {
-            span.addTools(tools);
+        if functionTools.length() > 0 {
+            span.addTools(functionTools);
             DeepseekFunction[] deepseekFunctions = [];
-            foreach ai:ChatCompletionFunctions toolFunction in tools {
+            foreach ai:ChatCompletionFunctions toolFunction in functionTools {
                 map<json>? parameters = toolFunction.parameters;
                 // Deepseek does not allow the NULL type when a function has no parameters,
                 // so avoid sending the schema in such cases.

--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -86,19 +86,19 @@ public isolated client class ModelProvider {
     # + stop - Stop sequence to stop the completion
     # + return - Function to be called, chat response or an error in-case of failures
     isolated remote function chat(ai:ChatMessage[]|ai:ChatUserMessage messages,
-            (ai:ChatCompletionFunctions|ai:InbuiltModelTool)[] tools = [], string? stop = ())
+            (ai:ChatCompletionFunctions|ai:BuiltInTool)[] tools = [], string? stop = ())
     returns ai:ChatAssistantMessage|ai:Error {
         string[] unsupportedTools = [];
         ai:ChatCompletionFunctions[] functionTools = [];
         foreach var tool in tools {
-            if tool is ai:InbuiltModelTool {
+            if tool is ai:BuiltInTool {
                 unsupportedTools.push(tool.name);
             } else {
                 functionTools.push(tool);
             }
         }
         if unsupportedTools.length() > 0 {
-            return error ai:Error(string `Inbuilt tools [${string:'join(", ", ...unsupportedTools)}] are not supported.`);
+            return error ai:Error(string `Built-in tools [${string:'join(", ", ...unsupportedTools)}] are not supported.`);
         }
 
         observe:ChatSpan span = observe:createChatSpan(self.modelType);

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -239,3 +239,16 @@ function testGenerateMethodWithArrayUnionRecord2() returns ai:Error? {
    Cricketers7[]|Cricketers8|error result = deepseekProvider->generate(`Name a random world class cricketer`);
     test:assertTrue(result is Cricketers8);
 }
+
+// ===== Built-in tool tests =====
+
+@test:Config
+function testChatWithBuiltInToolError() returns error? {
+    ai:ChatUserMessage userMsg = {role: "user", content: "Search the web for latest news"};
+    ai:BuiltInTool webSearchTool = {name: "web_search"};
+    ai:ChatAssistantMessage|ai:Error result = deepseekProvider->chat(userMsg, [webSearchTool]);
+    test:assertTrue(result is ai:Error);
+    string errorMsg = (<ai:Error>result).message();
+    test:assertTrue(errorMsg.includes("Built-in tools [web_search] are not supported."),
+            string `expected built-in tool error, found: ${errorMsg}`);
+}

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -252,3 +252,15 @@ function testChatWithBuiltInToolError() returns error? {
     test:assertTrue(errorMsg.includes("Built-in tools [web_search] are not supported."),
             string `expected built-in tool error, found: ${errorMsg}`);
 }
+
+@test:Config
+function testChatWithMixedToolsError() returns error? {
+    ai:ChatUserMessage userMsg = {role: "user", content: "Search the web for latest news"};
+    ai:BuiltInTool webSearchTool = {name: "web_search"};
+    ai:ChatCompletionFunctions functionTool = {name: "get_weather", description: "Get weather", parameters: {}};
+    ai:ChatAssistantMessage|ai:Error result = deepseekProvider->chat(userMsg, [functionTool, webSearchTool]);
+    test:assertTrue(result is ai:Error);
+    string errorMsg = (<ai:Error>result).message();
+    test:assertTrue(errorMsg.includes("Built-in tools [web_search] are not supported."),
+            string `expected built-in tool error, found: ${errorMsg}`);
+}

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -17,3 +17,15 @@ groupId = "io.ballerina.lib"
 artifactId = "ai.deepseek-native"
 version = "@toml.version@"
 path = "../native/build/libs/ai.deepseek-native-@project.version@.jar"
+
+[[dependency]]
+org="ballerina"
+name="ai"
+version="1.10.0"
+repository="local"
+
+[[dependency]]
+org="ballerina"
+name="data.jsondata"
+version="1.1.4"
+repository="local"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.lib
 version=1.1.2-SNAPSHOT
-ballerinaLangVersion=2201.12.0
+ballerinaLangVersion=2201.13.0
 
 shadowJarPluginVersion=8.1.1
 downloadPluginVersion=5.4.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.lib
-version=1.1.2-SNAPSHOT
-ballerinaLangVersion=2201.13.0
+version=1.2.0-SNAPSHOT
+ballerinaLangVersion=2201.12.0
 
 shadowJarPluginVersion=8.1.1
 downloadPluginVersion=5.4.0


### PR DESCRIPTION
Add built-in tool abstraction implementation

Fixes:
https://github.com/wso2-enterprise/integration-engineering/issues/80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Add Inbuilt tools API abstraction

This pull request introduces a built-in tool abstraction implementation for the DeepSeek AI module. The primary changes include:

### Core Functionality
- Updated the `chat` function signature in `model-provider.bal` to support both traditional `ai:ChatCompletionFunctions` and the new `ai:BuiltInTool` types
- Implemented runtime validation to handle unsupported built-in tools with appropriate error reporting
- Refactored tool processing logic to filter and separate built-in tools from traditional function tools, maintaining backward compatibility while enabling the new abstraction

### Dependency and Configuration Updates
- Bumped the module version from 1.1.1 to 1.1.2
- Updated Ballerina language distribution version to 2201.13.0
- Added dependencies on the `ai` module (version 1.10.0) and `data.jsondata` (version 1.1.4)
- Updated multiple dependent packages including http, log, mcp, oauth2, observe, and others
- Updated build configuration and compiler plugin references to align with the new version

### Deliverables
The changes enable the module to provide an abstraction layer for built-in tools while maintaining full backward compatibility with existing code that uses traditional function-based tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->