### PR TITLE
 Fix generate method failure for text chunk

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ icon="icon.png"
 name = "ai.deepseek"
 org = "ballerinax"
 repository = "https://github.com/ballerina-platform/module-ballerinax-ai.deepseek"
-version = "1.1.2"
+version = "1.1.3"
 
 [platform.java21]
 graalvmCompatible = true
@@ -15,5 +15,5 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ai.deepseek-native"
-version = "1.1.2"
-path = "../native/build/libs/ai.deepseek-native-1.1.2.jar"
+version = "1.1.3"
+path = "../native/build/libs/ai.deepseek-native-1.1.3-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "ai-deepseek-compiler-plugin"
 class = "io.ballerina.lib.ai.deepseek.AiDeepseekCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ai.deepseek-compiler-plugin-1.1.2.jar"
+path = "../compiler-plugin/build/libs/ai.deepseek-compiler-plugin-1.1.3-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.0.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -148,6 +148,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
 ]
+modules = [
+	{org = "ballerina", packageName = "io", moduleName = "io"}
+]
 
 [[package]]
 org = "ballerina"
@@ -395,6 +398,7 @@ version = "1.1.3"
 dependencies = [
 	{org = "ballerina", name = "ai"},
 	{org = "ballerina", name = "http"},
+	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "time"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -148,9 +148,6 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
 ]
-modules = [
-	{org = "ballerina", packageName = "io", moduleName = "io"}
-]
 
 [[package]]
 org = "ballerina"
@@ -398,7 +395,6 @@ version = "1.1.3"
 dependencies = [
 	{org = "ballerina", name = "ai"},
 	{org = "ballerina", name = "http"},
-	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "time"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -110,7 +110,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.9"
+version = "2.14.10"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -391,7 +391,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "ai.deepseek"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
 	{org = "ballerina", name = "ai"},
 	{org = "ballerina", name = "http"},

--- a/ballerina/provider_utils.bal
+++ b/ballerina/provider_utils.bal
@@ -104,15 +104,14 @@ isolated function generateChatCreationContent(ai:Prompt prompt) returns string|a
         string str = strings[i + 1];
         anydata insertion = insertions[i];
 
-        if insertion is ai:TextDocument {
+        if insertion is ai:TextDocument|ai:TextChunk {
             promptStr += insertion.content + " " + str;
             continue;
         }
 
-        if insertion is ai:TextDocument[] {
-            foreach ai:TextDocument doc in insertion {
+        if insertion is (ai:TextDocument|ai:TextChunk)[] {
+            foreach ai:TextDocument|ai:TextChunk doc in insertion {
                 promptStr += doc.content + " ";
-
             }
             promptStr += str;
             continue;

--- a/ballerina/tests/test_utils.bal
+++ b/ballerina/tests/test_utils.bal
@@ -59,6 +59,14 @@ isolated function getExpectedParameterSchema(string message) returns map<json> {
         return expectedParameterSchemaStringForRateBlog2;
     }
 
+    if message.startsWith("How would you rate these text chunks") {
+        return expectedParameterSchemaStringForRateBlog5;
+    }
+
+    if message.startsWith("How would you rate this text chunk") {
+        return expectedParameterSchemaStringForRateBlog;
+    }
+
     if message.startsWith("What's the output of the Ballerina code below?") {
         return expectedParamterSchemaStringForBalProgram;
     }
@@ -96,7 +104,7 @@ isolated function getExpectedParameterSchema(string message) returns map<json> {
     }
 
     if message.startsWith("Give me a random joke") {
-        return {"type":"object","properties":{"result":{"anyOf":[{"type":"string"},{"type":"null"}]}}};
+        return {"type": "object", "properties": {"result": {"anyOf": [{"type": "string"}, {"type": "null"}]}}};
     }
 
     if message.startsWith("Name a random world class cricketer in India") {
@@ -143,6 +151,14 @@ isolated function getTheMockLLMResult(string message) returns string {
         return review;
     }
 
+    if message.startsWith("How would you rate these text chunks") {
+        return string `{"result": [${review}, ${review}]}`;
+    }
+
+    if message.startsWith("How would you rate this text chunk") {
+        return {result: 4}.toJsonString();
+    }
+
     if message.startsWith("What is 1 + 1?") {
         return "{\"result\": 2}";
     }
@@ -184,7 +200,7 @@ isolated function getTheMockLLMResult(string message) returns string {
         return review;
     }
 
-        if message.startsWith("Name a random world class cricketer in India") {
+    if message.startsWith("Name a random world class cricketer in India") {
         return "{\"result\": {\"name\": \"Sanga\"}}";
     }
 
@@ -229,7 +245,7 @@ isolated function getTestServiceResponse(string content) returns DeepSeekChatCom
     ]
 };
 
-isolated function getExpectedPrompt(string message) returns string {
+isolated function getExpectedPrompt(string message) returns json {
     if message.startsWith("Rate this blog") {
         return expectedPromptStringForRateBlog;
     }
@@ -244,6 +260,14 @@ isolated function getExpectedPrompt(string message) returns string {
 
     if message.startsWith("Please rate this blog") {
         return expectedPromptStringForRateBlog2;
+    }
+
+    if message.startsWith("How would you rate these text chunks") {
+        return expectedContentPartsForTextChunkArray;
+    }
+
+    if message.startsWith("How would you rate this text chunk") {
+        return expectedContentPartsForTextChunk;
     }
 
     if message.startsWith("What is 1 + 1?") {
@@ -301,7 +325,7 @@ isolated function getExpectedPrompt(string message) returns string {
     }
 
     if message.startsWith("Name top 10 world class cricketers") {
-        return "Name top 10 world class cricketers"; 
+        return "Name top 10 world class cricketers";
     }
 
     if message.startsWith("Name a random world class cricketer in India") {

--- a/ballerina/tests/test_values.bal
+++ b/ballerina/tests/test_values.bal
@@ -74,7 +74,7 @@ final string expectedPromptStringForRateBlog7 =
 final string expectedPromptStringForRateBlog8 =
     string `How would you rate this text blog out of 10, Title: ${blog1.title} Content: ${blog1.content} .`;
 
-final string expectedPromptStringForRateBlog9 = string 
+final string expectedPromptStringForRateBlog9 = string
     `How would you rate this text blogs out of 10. Title: ${blog1.title} Content: ${blog1.content} Title: ${blog1.title} Content: ${blog1.content} . Thank you!`;
 
 final string expectedPromptStringForRateBlog10 = string `Evaluate this blogs out of 10.
@@ -101,14 +101,11 @@ const expectedPromptStringForBalProgram = string `What's the output of the Balle
 
 const expectedPromptStringForCountry = string `Which country is known as the pearl of the Indian Ocean?`;
 
-const expectedParameterSchemaStringForRateBlog =
-    {"type": "object", "properties": {"result": {"type": "integer"}}};
+const expectedParameterSchemaStringForRateBlog = {"type": "object", "properties": {"result": {"type": "integer"}}};
 
-const expectedParameterSchemaStringForRateBlog7 =
-    {"type":"object","properties":{"result":{"type":["integer", "null"]}}};
+const expectedParameterSchemaStringForRateBlog7 = {"type": "object", "properties": {"result": {"type": ["integer", "null"]}}};
 
-const expectedParameterSchemaStringForRateBlog2 =
-    {
+const expectedParameterSchemaStringForRateBlog2 = {
     "type": "object",
     "required": ["comment", "rating"],
     "properties": {
@@ -117,11 +114,9 @@ const expectedParameterSchemaStringForRateBlog2 =
     }
 };
 
-const expectedParameterSchemaStringForRateBlog3 =
-    {"type": "object", "properties": {"result": {"type": "boolean"}}};
+const expectedParameterSchemaStringForRateBlog3 = {"type": "object", "properties": {"result": {"type": "boolean"}}};
 
-const expectedParameterSchemaStringForRateBlog4 =
-    {
+const expectedParameterSchemaStringForRateBlog4 = {
     "type": "object",
     "properties": {
         "result": {
@@ -135,8 +130,7 @@ const expectedParameterSchemaStringForRateBlog4 =
     }
 };
 
-const expectedParameterSchemaStringForRateBlog5 =
-    {
+const expectedParameterSchemaStringForRateBlog5 = {
     "type": "object",
     "properties": {
         "result": {
@@ -153,8 +147,7 @@ const expectedParameterSchemaStringForRateBlog5 =
     }
 };
 
-const expectedParameterSchemaStringForRateBlog6 =
-    {
+const expectedParameterSchemaStringForRateBlog6 = {
     "type": "object",
     "properties": {
         "result": {
@@ -166,62 +159,18 @@ const expectedParameterSchemaStringForRateBlog6 =
     }
 };
 
-const expectedParamterSchemaStringForBalProgram =
-    {"type": "object", "properties": {"result": {"type": "integer"}}};
+const expectedParamterSchemaStringForBalProgram = {"type": "object", "properties": {"result": {"type": "integer"}}};
 
-const expectedParamterSchemaStringForCountry =
-    {"type": "object", "properties": {"result": {"type": "string"}}};
+const expectedParamterSchemaStringForCountry = {"type": "object", "properties": {"result": {"type": "string"}}};
 
-
-const expectedParamSchemaForArrayUnionNull =
-    {
-        "type": "object",
-        "properties": {
-            "result": {
-                "anyOf": [
-                    {
-                        "type": "array",
-                        "items": {
-                            "required": [
-                                "name"
-                            ],
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "type": "null"
-                    }
-                ]
-            }
-        }
-    };
-
-const expectedParameterSchemaForArrayUnionRec =
-    {
-        "type": "object",
-        "properties": {
-            "result": {
-                "anyOf": [
-                    {
-                        "type": "array",
-                        "items": {
-                            "required": [
-                                "name"
-                            ],
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    {
+const expectedParamSchemaForArrayUnionNull = {
+    "type": "object",
+    "properties": {
+        "result": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {
                         "required": [
                             "name"
                         ],
@@ -232,46 +181,35 @@ const expectedParameterSchemaForArrayUnionRec =
                             }
                         }
                     }
-                ]
-            }
+                },
+                {
+                    "type": "null"
+                }
+            ]
         }
-    };
+    }
+};
 
-const expectedParameterSchemaForArrayUnionBasicType = 
-    {
-        "type": "object",
-        "properties": {
-            "result": {
-                "anyOf": [
-                    {
-                        "type": "array",
-                        "items": {
-                            "required": [
-                                "name"
-                            ],
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                }
+const expectedParameterSchemaForArrayUnionRec = {
+    "type": "object",
+    "properties": {
+        "result": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "required": [
+                            "name"
+                        ],
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
                             }
                         }
-                    },
-                    {
-                        "type": "string"
                     }
-                ]
-            }
-        }
-    };
-
-const expectedParameterSchemaForArrayOnly = 
-    {
-        "type": "object",
-        "properties": {
-            "result": {
-                "type": "array",
-                "items": {
+                },
+                {
                     "required": [
                         "name"
                     ],
@@ -282,17 +220,19 @@ const expectedParameterSchemaForArrayOnly =
                         }
                     }
                 }
-            }
+            ]
         }
-    };
+    }
+};
 
-const expectedParameterSchemaForRecUnionBasicType = 
-    {
-        "type": "object",
-        "properties": {
-            "result": {
-                "anyOf": [
-                    {
+const expectedParameterSchemaForArrayUnionBasicType = {
+    "type": "object",
+    "properties": {
+        "result": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {
                         "required": [
                             "name"
                         ],
@@ -302,36 +242,95 @@ const expectedParameterSchemaForRecUnionBasicType =
                                 "type": "string"
                             }
                         }
-                    },
-                    {
+                    }
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        }
+    }
+};
+
+const expectedParameterSchemaForArrayOnly = {
+    "type": "object",
+    "properties": {
+        "result": {
+            "type": "array",
+            "items": {
+                "required": [
+                    "name"
+                ],
+                "type": "object",
+                "properties": {
+                    "name": {
                         "type": "string"
                     }
-                ]
+                }
             }
         }
-    };
+    }
+};
 
-const expectedParameterSchemaForRecUnionNull = 
-    {
-        "type": "object",
-        "properties": {
-            "result": {
-                "anyOf": [
-                    {
-                        "required": [
-                            "name"
-                        ],
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            }
+const expectedParameterSchemaForRecUnionBasicType = {
+    "type": "object",
+    "properties": {
+        "result": {
+            "anyOf": [
+                {
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
                         }
-                    },
-                    {
-                        "type": "null"
                     }
-                ]
-            }
+                },
+                {
+                    "type": "string"
+                }
+            ]
         }
-    };
+    }
+};
+
+const expectedParameterSchemaForRecUnionNull = {
+    "type": "object",
+    "properties": {
+        "result": {
+            "anyOf": [
+                {
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        }
+    }
+};
+
+const expectedContentPartsForTextChunk = string `How would you rate this text chunk content out of 10.` +
+    string ` Title: Tips for Growing a Beautiful Garden Content: Spring is the perfect time to start your garden. 
+        Begin by preparing your soil with organic compost and ensure proper drainage. 
+        Choose plants suitable for your climate zone, and remember to water them regularly. 
+        Don't forget to mulch to retain moisture and prevent weeds. .`;
+
+const expectedContentPartsForTextChunkArray = string `How would you rate these text chunks out of 10.` +
+    string ` Title: Tips for Growing a Beautiful Garden Content: Spring is the perfect time to start your garden. 
+        Begin by preparing your soil with organic compost and ensure proper drainage. 
+        Choose plants suitable for your climate zone, and remember to water them regularly. 
+        Don't forget to mulch to retain moisture and prevent weeds. Title: Tips for Growing a Beautiful Garden Content: Spring is the perfect time to start your garden. 
+        Begin by preparing your soil with organic compost and ensure proper drainage. 
+        Choose plants suitable for your climate zone, and remember to water them regularly. 
+        Don't forget to mulch to retain moisture and prevent weeds. . Thank you!`;

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -141,7 +141,7 @@ function testGenerateMethodWithInvalidRecordType() returns ai:Error? {
     string msg = (<error>rating).message();
     test:assertTrue(rating is error);
     test:assertTrue(msg.includes(RUNTIME_SCHEMA_NOT_SUPPORTED_ERROR_MESSAGE),
-        string `expected error message to contain: ${RUNTIME_SCHEMA_NOT_SUPPORTED_ERROR_MESSAGE}, but found ${msg}`);
+            string `expected error message to contain: ${RUNTIME_SCHEMA_NOT_SUPPORTED_ERROR_MESSAGE}, but found ${msg}`);
 }
 
 type ProductNameArray ProductName[];
@@ -153,7 +153,6 @@ function testGenerateMethodWithInvalidRecordArrayType2() returns ai:Error? {
     test:assertTrue(rating is error);
     test:assertTrue((<error>rating).message().includes(ERROR_MESSAGE));
 }
-
 
 type Cricketers record {|
     string name;
@@ -221,7 +220,6 @@ function testGenerateMethodWithArrayUnionBasicType() returns error? {
     test:assertTrue(result is Cricketers3[]);
 }
 
-
 @test:Config
 function testGenerateMethodWithArrayUnionNull() returns error? {
     Cricketers4[]? result = check deepseekProvider->generate(`Name 10 world class cricketers`);
@@ -236,6 +234,22 @@ function testGenerateMethodWithArrayUnionRecord() returns ai:Error? {
 
 @test:Config
 function testGenerateMethodWithArrayUnionRecord2() returns ai:Error? {
-   Cricketers7[]|Cricketers8|error result = deepseekProvider->generate(`Name a random world class cricketer`);
+    Cricketers7[]|Cricketers8|error result = deepseekProvider->generate(`Name a random world class cricketer`);
     test:assertTrue(result is Cricketers8);
+}
+
+@test:Config
+function testGenerateMethodWithTextChunk() returns error? {
+    ai:TextChunk chunk = {
+        content: string `Title: ${blog1.title} Content: ${blog1.content}`
+    };
+    ai:TextChunk[] chunks = [chunk, chunk];
+    int maxScore = 10;
+
+    int rating = check deepseekProvider->generate(`How would you rate this text chunk content out of ${maxScore}. ${chunk}.`);
+    test:assertEquals(rating, 4);
+
+    ReviewArray result = check deepseekProvider->generate(`How would you rate these text chunks out of ${maxScore}. ${chunks}. Thank you!`);
+    Review r = check review.fromJsonStringWithType();
+    test:assertEquals(result, [r, r]);
 }


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/wso2/product-integrator/issues/370

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [x] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes an issue where the ModelProvider `generate` method failed when accepting `ai:TextChunk` inputs, throwing an error stating "Only text, image and audio documents are supported." The fix extends input validation logic to properly handle both `ai:TextDocument` and `ai:TextChunk` types, as well as arrays of these types.

## Changes

**Core Fix:**
- Updated `generateChatCreationContent` function in `ballerina/provider_utils.bal` to expand type-guard checks and accept `ai:TextChunk` in addition to `ai:TextDocument`, maintaining the same content processing behavior

**Testing:**
- Added comprehensive test coverage with new test `testGenerateMethodWithTextChunk` in `ballerina/tests/tests.bal` that validates the `generate` method works correctly with both single and array inputs of `ai:TextChunk`
- Extended test utilities in `ballerina/tests/test_utils.bal` to support text chunk-related prompt patterns
- Updated expected content constants in `ballerina/tests/test_values.bal` to include scenarios for text chunk inputs

**Version Management:**
- Bumped package version from 1.1.2 to 1.1.3 across configuration files (`Ballerina.toml`, `CompilerPlugin.toml`, `Dependencies.toml`)
- Updated native dependency and compiler plugin artifact references to the new 1.1.3-SNAPSHOT version

## Impact

The `generate` method now properly accepts and processes `ai:TextChunk` inputs alongside existing `ai:TextDocument` support, improving flexibility in template injection and expanding the range of valid input types for the ModelProvider interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->