### PR TITLE
chore: update default max token count to 4096

### DIFF
--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -21,7 +21,7 @@ import ballerina/jballerina.java;
 import ballerina/time;
 
 const DEFAULT_DEEPSEEK_SERVICE_URL = "https://api.deepseek.com";
-const DEFAULT_MAX_TOKEN_COUNT = 512;
+const DEFAULT_MAX_TOKEN_COUNT = 4096;
 const DEFAULT_TEMPERATURE = 0.7d;
 
 # Deepseek is a client class that provides an interface for interacting with Deepseek Large Language Models.
@@ -138,7 +138,7 @@ public isolated client class ModelProvider {
             span.close(err);
             return err;
         }
-        
+
         span.addResponseId(response.id);
         int? inputTokens = response.usage?.prompt_tokens;
         if inputTokens is int {


### PR DESCRIPTION
## Purpose

Fixes: Increase the default maximum output token count for the DeepSeek model provider from `512` to `4096` to align with the DeepSeek API's recommended default and support longer model responses.

## Examples

```ballerina
import ballerinax/ai.deepseek;

public function main() returns error? {
    deepseek:ModelProvider model = check new (apiKey = "<DEEPSEEK_API_KEY>");
    // Now supports up to 4096 output tokens by default (previously 512)
}

