### PR TITLE
Clarify Overview so the Central summary distinguishes ai.deepseek

### DIFF
--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -1,8 +1,6 @@
 ## Overview
 
-DeepSeek provides high-performance large language models (LLMs) optimized for various natural language processing tasks.
-
-The DeepSeek connector offers APIs for connecting with DeepSeek Large Language Models (LLMs), enabling the integration of advanced conversational AI and language processing capabilities into applications.
+The `ai.deepseek` module provides a DeepSeek-backed `ModelProvider` implementation for the [`ballerina/ai`](https://central.ballerina.io/ballerina/ai/latest) agent framework. Use it to drive DeepSeek models (DeepSeek-V3, DeepSeek-Coder, and others) from Ballerina AI agents and other `ai`-module abstractions, rather than calling the DeepSeek REST API directly.
 
 ### Key Features
 


### PR DESCRIPTION
### Purpose

The first paragraph of the package Overview is what Ballerina Central stores as the package **summary**, and that summary is the `description` the Ballerina Copilot **library-search tool** returns to the agent when it selects a library. Across the OpenAI / Azure OpenAI / `ai.*` packages this first paragraph was a generic vendor blurb, so their summaries were nearly identical and an agent could not reliably tell them apart (e.g. an agent-framework model provider vs a direct REST connector).

### Change

Rewrite the Overview's first paragraph into a single, **capability-first** sentence that states what this module uniquely is — grounded in its actual API and `Ballerina.toml` type keywords — so the summary alone disambiguates it from its siblings. The now-redundant generic second paragraph is merged away. **Key Features** and everything below are untouched; `Module.md` is synced where present.

> Draft: opening for wording review. Part of a coordinated pass to disambiguate the AI/LLM package summaries surfaced by Copilot library search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)